### PR TITLE
Adjust teamleader.eu urls to focus.teamleader.eu

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This service provides contacts from Teamleader for the CLINQ app.
 Please create `.env` file or provide following environment variables:
 
 - OAUTH_IDENTIFIER - Name of CRM Bridge
-- TEAMLEADER_CLIENT_ID - Client ID of registered Teamleader App at https://marketplace.teamleader.eu/eu/en/build
+- TEAMLEADER_CLIENT_ID - Client ID of registered Teamleader App at https://marketplace.focus.teamleader.eu/eu/en/build
 - TEAMLEADER_CLIENT_SECRET - Client Secret of registered Teamleader App, provided by Teamleader
 - TEAMLEADER_REDIRECT_URL - URL of current bridge, must match with registered data at Teamleader
 

--- a/src/util/access-token.ts
+++ b/src/util/access-token.ts
@@ -24,7 +24,7 @@ export async function authorizeApiKey(apiKey: string, refresh: boolean): Promise
 function getNewAccessToken(refreshToken: string): Promise<ITeamleaderAuthResponse> {
     const { TEAMLEADER_CLIENT_ID, TEAMLEADER_CLIENT_SECRET } = parseEnvironment();
     const reqOptions = {
-        url: `https://app.teamleader.eu/oauth2/access_token`,
+        url: `https://focus.teamleader.eu/oauth2/access_token`,
         method: RequestMethods.POST,
         body: {
             refresh_token: refreshToken,

--- a/src/util/teamleader.ts
+++ b/src/util/teamleader.ts
@@ -10,7 +10,7 @@ import {
 import { AccessTokenExpiredException, isContactResponse, isUpdateResponse, makeRequest } from './make-request';
 import parseEnvironment from './parse-environment';
 
-const apiDomain = 'https://api.teamleader.eu';
+const apiDomain = 'https://api.focus.teamleader.eu';
 
 async function _createContact(
     accessToken: string,
@@ -142,7 +142,7 @@ export const deleteContact = refreshTokenOnError(_deleteContact);
 export function getTokens(code: string): Promise<ITeamleaderAuthResponse> {
     const { TEAMLEADER_CLIENT_ID, TEAMLEADER_CLIENT_SECRET, TEAMLEADER_REDIRECT_URL } = parseEnvironment();
     const reqOptions = {
-        url: `https://app.teamleader.eu/oauth2/access_token`,
+        url: `https://focus.teamleader.eu/oauth2/access_token`,
         method: RequestMethods.POST,
         body: {
             code,
@@ -157,7 +157,7 @@ export function getTokens(code: string): Promise<ITeamleaderAuthResponse> {
 
 export function getOAuth2RedirectUrl(): string {
     const { TEAMLEADER_CLIENT_ID, TEAMLEADER_REDIRECT_URL } = parseEnvironment();
-    return 'https://app.teamleader.eu/oauth2/authorize?' + querystring.encode({
+    return 'https://focus.teamleader.eu/oauth2/authorize?' + querystring.encode({
             client_id: TEAMLEADER_CLIENT_ID,
             response_type: 'code',
             redirect_uri: TEAMLEADER_REDIRECT_URL


### PR DESCRIPTION
The Teamleader application has been renamed to Teamleader Focus, more info about this can be found [here](https://www.teamleader.eu/blog/new-names-teamleader-focus-orbit). This product name change also means that the application, api, marketplace, etc. have a new home under [focus.teamleader.eu](https://focus.teamleader.eu).

This PR changes the Teamleader URLs in this repo to point to [focus.teamleader.eu](https://focus.teamleader.eu). The switch to these new URLs isn't urgent though, the old URLs will remain available for some time.